### PR TITLE
use native actions + bump checkout version

### DIFF
--- a/.github/workflows/_deploy-client-aws.yaml
+++ b/.github/workflows/_deploy-client-aws.yaml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Configure Kubeconfig w/ EKS"
         run: aws eks update-kubeconfig --name ${{ secrets.CLUSTER_PREFIX }}-prod --region ${{ env.AWS_REGION }}

--- a/.github/workflows/_deploy-client-gke.yaml
+++ b/.github/workflows/_deploy-client-gke.yaml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - id: "auth"
         uses: "google-github-actions/auth@v0"

--- a/.github/workflows/_deploy-coprocessor-aws.yaml
+++ b/.github/workflows/_deploy-coprocessor-aws.yaml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Configure Kubeconfig w/ EKS"
         run: aws eks update-kubeconfig --name ${{ secrets.CLUSTER_PREFIX }}-${{ inputs.cluster_suffix }} --region ${{ env.AWS_REGION }}

--- a/.github/workflows/_deploy-coprocessor-gke.yaml
+++ b/.github/workflows/_deploy-coprocessor-gke.yaml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - id: "auth"
         uses: "google-github-actions/auth@v0"

--- a/.github/workflows/_deploy-loadtest-infra-aws.yaml
+++ b/.github/workflows/_deploy-loadtest-infra-aws.yaml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Configure Kubeconfig w/ EKS"
         run: aws eks update-kubeconfig --name ${{ secrets.CLUSTER_PREFIX }}-prod --region ${{ env.AWS_REGION }}

--- a/.github/workflows/_deploy-loadtest-infra-gke.yaml
+++ b/.github/workflows/_deploy-loadtest-infra-gke.yaml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - id: "auth"
         uses: "google-github-actions/auth@v0"

--- a/.github/workflows/_deploy-otel-collector-aws.yaml
+++ b/.github/workflows/_deploy-otel-collector-aws.yaml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Configure Kubeconfig w/ EKS"
         run: aws eks update-kubeconfig --name ${{ secrets.CLUSTER_PREFIX }}-prod --region ${{ env.AWS_REGION }}

--- a/.github/workflows/_deploy-otel-collector-gke.yaml
+++ b/.github/workflows/_deploy-otel-collector-gke.yaml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - id: "auth"
         uses: "google-github-actions/auth@v0"

--- a/.github/workflows/_deploy-router-aws.yaml
+++ b/.github/workflows/_deploy-router-aws.yaml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Configure Kubeconfig w/ EKS"
         run: aws eks update-kubeconfig --name ${{ secrets.CLUSTER_PREFIX }}-${{ inputs.environment }} --region ${{ env.AWS_REGION }}

--- a/.github/workflows/_deploy-router-gke.yaml
+++ b/.github/workflows/_deploy-router-gke.yaml
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - id: "auth"
         uses: "google-github-actions/auth@v0"

--- a/.github/workflows/_deploy-subgraphs-aws.yaml
+++ b/.github/workflows/_deploy-subgraphs-aws.yaml
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Configure Kubeconfig w/ EKS"
         run: aws eks update-kubeconfig --name ${{ secrets.CLUSTER_PREFIX }}-${{ inputs.cluster_suffix }} --region ${{ env.AWS_REGION }}

--- a/.github/workflows/_deploy-subgraphs-gke.yaml
+++ b/.github/workflows/_deploy-subgraphs-gke.yaml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - id: "auth"
         uses: "google-github-actions/auth@v0"

--- a/.github/workflows/_rover-client-pq-publish.yml
+++ b/.github/workflows/_rover-client-pq-publish.yml
@@ -20,7 +20,6 @@ on:
 
 env:
   APOLLO_KEY: ${{ secrets.APOLLO_KEY }}
-  APOLLO_GRAPH_REF: ${{ secrets.APOLLO_GRAPH_ID }}
   APOLLO_VCS_COMMIT: ${{ github.event.pull_request.head.sha }}
 
 jobs:
@@ -30,33 +29,20 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Rover
-        run: |
-          curl -sSL https://rover.apollo.dev/nix/latest | sh
-          echo "$HOME/.rover/bin" >> $GITHUB_PATH
+        uses: apollographql-gh-actions/install-rover@v1
 
       - name: Generate PQ manifest
         run: |
           cd ./client/
-          npm install --save-dev @apollo/generate-persisted-query-manifest
           npx generate-persisted-query-manifest 
           
-      - name: Publish to dev
-        if: inputs.environment == 'dev'
-        run: |
-          cd client
-          rover persisted-queries publish \
-          --graph-id ${{ secrets.APOLLO_GRAPH_ID }} \
-          --list-id ${{ secrets.APOLLO_PQ_DEV_ID }} \
-          --manifest ./persisted-query-manifest.json 
+      - name: Publish PQ Manifest
+        uses: apollographql-gh-actions/rover-persisted-queries-publish@v1
+        with:
+          apollo-key: ${{ secrets.APOLLO_KEY }}
+          graph-ref: ${{ secrets.APOLLO_GRAPH_ID }}@${{ inputs.environment }}
+          manifest: ./client/persisted-query-manifest.json
         
-      - name: Publish to prod
-        if: inputs.environment == 'prod'
-        run: |
-          cd client
-          rover persisted-queries publish \
-          --graph-id ${{ secrets.APOLLO_GRAPH_ID }} \
-          --list-id ${{ secrets.APOLLO_PQ_PROD_ID }} \
-          --manifest ./persisted-query-manifest.json 

--- a/.github/workflows/_rover-subgraph-check.yml
+++ b/.github/workflows/_rover-subgraph-check.yml
@@ -28,15 +28,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Rover
-        run: |
-          curl -sSL https://rover.apollo.dev/nix/latest | sh
-          echo "$HOME/.rover/bin" >> $GITHUB_PATH
+        uses: apollographql-gh-actions/install-rover@v1
 
       - name: Rover Subgraph Check
-        run: |
-          rover subgraph check ${{ secrets.APOLLO_GRAPH_ID }}@${{ inputs.variant }} \
-            --name ${{ inputs.subgraph_name }} \
-            --schema ./subgraphs/${{inputs.subgraph_name}}/schema.graphql
+        uses: apollographql-gh-actions/rover-subgraph-check@v1
+        with:
+          apollo-key: ${{ secrets.APOLLO_KEY }}
+          graph-ref: ${{ secrets.APOLLO_GRAPH_ID }}@${{ inputs.variant }}
+          name: ${{ inputs.subgraph_name }}
+          schema: ./subgraphs/${{inputs.subgraph_name}}/schema.graphql

--- a/.github/workflows/_rover-subgraph-publish.yml
+++ b/.github/workflows/_rover-subgraph-publish.yml
@@ -18,7 +18,6 @@ on:
         required: true
 
 env:
-  APOLLO_KEY: ${{ secrets.APOLLO_KEY }}
   APOLLO_VCS_COMMIT: ${{ github.event.pull_request.head.sha }}
 
 jobs:
@@ -28,16 +27,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Rover
-        run: |
-          curl -sSL https://rover.apollo.dev/nix/latest | sh
-          echo "$HOME/.rover/bin" >> $GITHUB_PATH
+        uses: apollographql-gh-actions/install-rover@v1
 
       - name: Rover Subgraph Publish
-        run: |
-          rover subgraph publish ${{ secrets.APOLLO_GRAPH_ID }}@${{ inputs.variant }} \
-            --name ${{ inputs.subgraph_name }} \
-            --routing-url http://graphql.${{ inputs.subgraph_name }}.svc.cluster.local:4001 \
-            --schema ./subgraphs/${{inputs.subgraph_name}}/schema.graphql
+        uses: apollographql-gh-actions/rover-subgraph-publish@v1
+        with:
+          apollo-key: ${{ secrets.APOLLO_KEY }}
+          graph-ref: ${{ secrets.APOLLO_GRAPH_ID }}@${{ inputs.variant }}
+          name: ${{ inputs.subgraph_name }}
+          schema: ./subgraphs/${{inputs.subgraph_name}}/schema.graphql
+          routing-url: http://graphql.${{ inputs.subgraph_name }}.svc.cluster.local:4001
+

--- a/.github/workflows/_run-loadtest-aws.yaml
+++ b/.github/workflows/_run-loadtest-aws.yaml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Configure Kubeconfig w/ EKS"
         run: aws eks update-kubeconfig --name ${{ secrets.CLUSTER_PREFIX }}-prod --region ${{ env.AWS_REGION }}

--- a/.github/workflows/_run-loadtest-gke.yaml
+++ b/.github/workflows/_run-loadtest-gke.yaml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - id: "auth"
         uses: "google-github-actions/auth@v0"

--- a/.github/workflows/_uninstall-router-aws.yaml
+++ b/.github/workflows/_uninstall-router-aws.yaml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Configure Kubeconfig w/ EKS"
         run: aws eks update-kubeconfig --name ${{ secrets.CLUSTER_PREFIX }}-${{ inputs.environment }} --region ${{ env.AWS_REGION }}

--- a/.github/workflows/_uninstall-router-gke.yaml
+++ b/.github/workflows/_uninstall-router-gke.yaml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - id: "auth"
         uses: "google-github-actions/auth@v0"

--- a/.github/workflows/merge-to-main.yaml
+++ b/.github/workflows/merge-to-main.yaml
@@ -21,7 +21,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2.0.0
@@ -58,7 +58,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2.0.0
@@ -98,7 +98,7 @@ jobs:
         subgraph: [checkout, discovery, inventory, orders, products, reviews, shipping, users]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2.0.0

--- a/.github/workflows/pr-check-code.yaml
+++ b/.github/workflows/pr-check-code.yaml
@@ -8,7 +8,7 @@ jobs:
   npm-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/pr-check-deploy.yaml
+++ b/.github/workflows/pr-check-deploy.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Helm lint
         id: list-changed


### PR DESCRIPTION
Bumps the `actions/checkout` version to `v4` and moves all `rover` related steps with the appropriate one from the official marketplace instead. 