### PR TITLE
[AS-239] Non-OCI Router Helm chart examples

### DIFF
--- a/.github/workflows/validate-non-oci-helm.yml
+++ b/.github/workflows/validate-non-oci-helm.yml
@@ -1,0 +1,92 @@
+name: Validate non-OCI Helm examples
+
+# Renders the examples/router-helm-non-oci values files against the upstream
+# Apollo Router chart and asserts they are correct. Template-only render (no
+# cluster needed); catches schema/nesting regressions like the image override
+# silently falling back to the upstream default.
+
+on:
+  pull_request:
+    paths:
+      - "examples/router-helm-non-oci/**"
+      - ".github/workflows/validate-non-oci-helm.yml"
+  workflow_dispatch: {}
+
+jobs:
+  helm-template:
+    runs-on: ubuntu-latest
+    env:
+      # Expected mirrored image after the override is applied.
+      EXPECTED_IMAGE: "registry.example.com/apollo/router:v2.10.0"
+      # Upstream default that must NOT survive the override.
+      UPSTREAM_IMAGE: "ghcr.io/apollographql/router"
+      # Leave empty to pull the latest chart; pin a version here if desired.
+      CHART_VERSION: ""
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.2
+
+      - name: Install kubeconform
+        run: |
+          set -euo pipefail
+          curl -fsSL https://github.com/yannh/kubeconform/releases/download/v0.6.7/kubeconform-linux-amd64.tar.gz -o /tmp/kc.tgz
+          tar -xzf /tmp/kc.tgz -C /tmp kubeconform
+          sudo mv /tmp/kubeconform /usr/local/bin/kubeconform
+          kubeconform -v
+
+      - name: Pull Apollo Router chart
+        id: chart
+        run: |
+          set -euo pipefail
+          if [ -n "${CHART_VERSION}" ]; then
+            helm pull oci://ghcr.io/apollographql/helm-charts/router --version "${CHART_VERSION}"
+          else
+            helm pull oci://ghcr.io/apollographql/helm-charts/router
+          fi
+          CHART_TGZ="$(ls router-*.tgz | head -n1)"
+          echo "tgz=${CHART_TGZ}" >> "${GITHUB_OUTPUT}"
+          echo "Pulled chart: ${CHART_TGZ}"
+
+      - name: Render and validate each pattern
+        env:
+          CHART_TGZ: ${{ steps.chart.outputs.tgz }}
+        run: |
+          set -euo pipefail
+          base="examples/router-helm-non-oci"
+          fail=0
+          for pattern in pattern-a-local-chart pattern-b-private-registry; do
+            values="${base}/${pattern}/values.yaml"
+            out="/tmp/${pattern}.rendered.yaml"
+            echo "::group::helm template ${pattern}"
+            helm template router "${CHART_TGZ}" -f "${values}" | tee "${out}"
+            echo "::endgroup::"
+
+            if ! grep -q "${EXPECTED_IMAGE}" "${out}"; then
+              echo "::error file=${values}::rendered manifests do not reference the mirrored image ${EXPECTED_IMAGE}"
+              fail=1
+            fi
+            if grep -q "${UPSTREAM_IMAGE}" "${out}"; then
+              echo "::error file=${values}::rendered manifests still reference the upstream image ${UPSTREAM_IMAGE}; the override did not fully apply"
+              fail=1
+            fi
+
+            echo "::group::kubeconform ${pattern}"
+            kubeconform -ignore-missing-schemas -summary "${out}"
+            echo "::endgroup::"
+          done
+
+          # pattern-b must wire the imagePullSecret into the pod spec.
+          if ! grep -q "regcred" "/tmp/pattern-b-private-registry.rendered.yaml"; then
+            echo "::error file=${base}/pattern-b-private-registry/values.yaml::rendered manifests do not reference the regcred imagePullSecret"
+            fail=1
+          fi
+
+          if [ "${fail}" -ne 0 ]; then
+            echo "Helm example validation failed."
+            exit 1
+          fi
+          echo "All non-OCI Helm examples rendered and validated successfully."

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -14,3 +14,13 @@ paths = [
   "docs/mcp-production.md",
   "docs/mcp-auth0-claude-desktop.md",
 ]
+
+# Allowlist the kubernetes dockerconfigjson placeholder in the non-OCI Helm
+# example. The .dockerconfigjson value is base64 of {"auths":{}} (an empty
+# placeholder), not a real credential. See AS-239 / PR #35.
+[[rules]]
+  id = "kubernetes-secret-yaml"
+  [rules.allowlist]
+    paths = [
+      '''examples/router-helm-non-oci/pattern-b-private-registry/regcred\.example\.yaml$''',
+    ]

--- a/examples/router-helm-non-oci/README.md
+++ b/examples/router-helm-non-oci/README.md
@@ -1,0 +1,49 @@
+# Apollo Router Helm — non-OCI registry examples
+
+The official Apollo Router Helm chart is distributed as an [OCI artifact](https://helm.sh/docs/topics/registries/)
+on `oci://ghcr.io/apollographql/helm-charts/router`, and pulls the Router
+container image from the same OCI registry. Some customers run in environments
+where their cluster (or their CI runner) cannot reach OCI artifact registries
+— typically because the platform team only allows traditional `https://`
+Helm chart repositories and image registries.
+
+This directory contains two working patterns for those environments. **Both
+patterns use the same Router image** — that image is just a regular OCI image
+hosted on GHCR; what changes is _how_ you obtain the chart and _which registry_
+the cluster pulls the image from.
+
+| Pattern | Chart source | Image registry | Use when… |
+| --- | --- | --- | --- |
+| [`pattern-a-local-chart`](pattern-a-local-chart) | Local chart copy (git or tarball) | Your own Docker Hub / ECR / GCR / Harbor mirror | Cluster has no outbound OCI access; you mirror images into a private registry. |
+| [`pattern-b-private-registry`](pattern-b-private-registry) | Helm pull + values override | Private registry with `imagePullSecrets` | Cluster can fetch from a private registry that requires credentials. |
+
+> [!NOTE]
+> These examples target **Apollo Router 2.x** (chart `1.x`). Update the `image.tag` /
+> chart version pins to match your target Router release.
+
+## Mirror the image first
+
+Both patterns assume the Router image has been mirrored into the registry the
+cluster _can_ reach. The official image is published at
+`ghcr.io/apollographql/router:v2.10.0`. Typical mirror flow:
+
+```bash
+ROUTER_VERSION=v2.10.0
+
+# pull from upstream (run from a host with internet access)
+docker pull ghcr.io/apollographql/router:${ROUTER_VERSION}
+
+# re-tag and push to your registry of choice
+docker tag ghcr.io/apollographql/router:${ROUTER_VERSION} \
+  registry.example.com/apollo/router:${ROUTER_VERSION}
+docker push registry.example.com/apollo/router:${ROUTER_VERSION}
+```
+
+Once the image is in your registry, point `image.repository` and `image.tag` at
+it in the values file (see the per-pattern READMEs).
+
+## See also
+
+- Upstream chart README: <https://github.com/apollographql/router/tree/dev/helm/chart/router>
+- Apollo Router image releases: <https://github.com/apollographql/router/releases>
+- Router on Kubernetes docs: <https://www.apollographql.com/docs/router/containerization/kubernetes>

--- a/examples/router-helm-non-oci/pattern-a-local-chart/README.md
+++ b/examples/router-helm-non-oci/pattern-a-local-chart/README.md
@@ -1,0 +1,38 @@
+# Pattern A — vendored chart + mirrored image
+
+Use this pattern when **the cluster has no outbound OCI access at all**. You
+vendor the chart files into your own repo (or fetch the tarball once from a
+machine that _does_ have access) and reference a non-OCI image registry mirror.
+
+## Steps
+
+```bash
+# 1. One-time: pull the chart tarball from a host with OCI access and commit it
+helm pull oci://ghcr.io/apollographql/helm-charts/router \
+  --version 1.71.0 \
+  --destination ./vendor
+# yields ./vendor/router-1.71.0.tgz
+
+# 2. Mirror the Router image into your registry (see ../README.md)
+
+# 3. Install from the local tarball, overriding image source
+helm upgrade --install router ./vendor/router-1.71.0.tgz \
+  -f values.yaml \
+  -n apollo --create-namespace
+```
+
+## Files
+
+- [`values.yaml`](values.yaml) — annotated values for a non-OCI deployment.
+
+## Verifying the rendered manifests
+
+Before applying to a real cluster, render and inspect:
+
+```bash
+helm template router ./vendor/router-1.71.0.tgz -f values.yaml \
+  | grep -E 'image:|imagePullSecrets:'
+```
+
+You should see `image: registry.example.com/apollo/router:v2.10.0` — not the
+`ghcr.io/apollographql/...` default.

--- a/examples/router-helm-non-oci/pattern-a-local-chart/values.yaml
+++ b/examples/router-helm-non-oci/pattern-a-local-chart/values.yaml
@@ -7,43 +7,49 @@
 #     # tag derived from appVersion
 # OCI registries are tied to the chart version. Override here to point at a
 # mirrored registry that supports standard Docker pulls.
+#
+# Schema: https://github.com/apollographql/router/blob/main/helm/chart/router/values.yaml
+# All overrides below match the upstream chart's top-level layout. The `router:`
+# key is reserved for the Router YAML config (`router.configuration`, `router.args`)
+# and is intentionally not used in this example.
 
-router:
-  # The mirrored Router image. Replace registry.example.com with your registry
-  # (Docker Hub, ECR, GCR, Artifactory, Harbor, Nexus, etc.).
-  image:
-    repository: registry.example.com/apollo/router
-    tag: "v2.10.0" # pin explicitly; upstream chart uses appVersion as default
-    pullPolicy: IfNotPresent
+# The mirrored Router image. Replace registry.example.com with your registry
+# (Docker Hub, ECR, GCR, Artifactory, Harbor, Nexus, etc.).
+image:
+  repository: registry.example.com/apollo/router
+  tag: "v2.10.0" # pin explicitly; upstream chart uses appVersion as default
+  pullPolicy: IfNotPresent
 
-  # If your registry is private, reference an imagePullSecret. The secret
-  # itself must be created out-of-band (e.g. with `kubectl create secret
-  # docker-registry`). See pattern-b for an example.
-  # imagePullSecrets:
-  #   - name: regcred
+# If your registry is private, reference an imagePullSecret. The secret
+# itself must be created out-of-band (e.g. with `kubectl create secret
+# docker-registry`). See pattern-b for an example.
+# imagePullSecrets:
+#   - name: regcred
 
-  # GraphOS connection — unchanged from the OCI pattern. The router still
-  # pulls schema and config from Uplink over HTTPS, so this works in both
-  # environments without additional firewall rules.
-  managedFederation:
-    apolloGraphRef: my-graph@main
-    existingSecret: apollo-graphos-secret # contains APOLLO_KEY
+# GraphOS connection — unchanged from the OCI pattern. The router still
+# pulls schema and config from Uplink over HTTPS, so this works in both
+# environments without additional firewall rules.
+managedFederation:
+  graphRef: my-graph@main
+  existingSecret: apollo-graphos-secret # contains the graph API key
 
-  # Standard production hygiene — not specific to non-OCI but worth showing
-  # in a reference example.
-  replicaCount: 3
-  resources:
-    requests:
-      cpu: 500m
-      memory: 512Mi
-    limits:
-      cpu: "2"
-      memory: 2Gi
+# Standard production hygiene — not specific to non-OCI but worth showing
+# in a reference example.
+replicaCount: 3
+resources:
+  requests:
+    cpu: 500m
+    memory: 512Mi
+  limits:
+    cpu: "2"
+    memory: 2Gi
 
-  service:
-    type: ClusterIP
-    port: 80
-    targetPort: 4000
+service:
+  type: ClusterIP
+  port: 80
+  # Chart default routes traffic to the named container port `http` (4000).
+  # Override only if you've remapped the Router listen port.
+  targetport: http
 
-  serviceMonitor:
-    enabled: false # set true if you run kube-prometheus-stack
+serviceMonitor:
+  enabled: false # set true if you run kube-prometheus-stack

--- a/examples/router-helm-non-oci/pattern-a-local-chart/values.yaml
+++ b/examples/router-helm-non-oci/pattern-a-local-chart/values.yaml
@@ -1,0 +1,49 @@
+# Pattern A — non-OCI Router Helm values
+#
+# Apollo's upstream router chart defaults to:
+#   image:
+#     repository: ghcr.io/apollographql/router
+#     pullPolicy: IfNotPresent
+#     # tag derived from appVersion
+# OCI registries are tied to the chart version. Override here to point at a
+# mirrored registry that supports standard Docker pulls.
+
+router:
+  # The mirrored Router image. Replace registry.example.com with your registry
+  # (Docker Hub, ECR, GCR, Artifactory, Harbor, Nexus, etc.).
+  image:
+    repository: registry.example.com/apollo/router
+    tag: "v2.10.0" # pin explicitly; upstream chart uses appVersion as default
+    pullPolicy: IfNotPresent
+
+  # If your registry is private, reference an imagePullSecret. The secret
+  # itself must be created out-of-band (e.g. with `kubectl create secret
+  # docker-registry`). See pattern-b for an example.
+  # imagePullSecrets:
+  #   - name: regcred
+
+  # GraphOS connection — unchanged from the OCI pattern. The router still
+  # pulls schema and config from Uplink over HTTPS, so this works in both
+  # environments without additional firewall rules.
+  managedFederation:
+    apolloGraphRef: my-graph@main
+    existingSecret: apollo-graphos-secret # contains APOLLO_KEY
+
+  # Standard production hygiene — not specific to non-OCI but worth showing
+  # in a reference example.
+  replicaCount: 3
+  resources:
+    requests:
+      cpu: 500m
+      memory: 512Mi
+    limits:
+      cpu: "2"
+      memory: 2Gi
+
+  service:
+    type: ClusterIP
+    port: 80
+    targetPort: 4000
+
+  serviceMonitor:
+    enabled: false # set true if you run kube-prometheus-stack

--- a/examples/router-helm-non-oci/pattern-b-private-registry/README.md
+++ b/examples/router-helm-non-oci/pattern-b-private-registry/README.md
@@ -1,0 +1,49 @@
+# Pattern B — private registry with imagePullSecrets
+
+Use this pattern when **your cluster can reach a private registry**
+(Harbor, JFrog Artifactory, AWS ECR, internal Nexus, etc.) but cannot pull
+from the public `ghcr.io`. The chart itself is still installed by pointing
+`helm` at a one-time tarball, but the image is pulled from your private
+registry using credentials managed via a Kubernetes secret.
+
+## Steps
+
+```bash
+# 1. Create the docker-registry secret in the target namespace
+kubectl create namespace apollo --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl -n apollo create secret docker-registry regcred \
+  --docker-server=registry.example.com \
+  --docker-username='<bot user>' \
+  --docker-password='<bot token>' \
+  --docker-email='infra@example.com'
+
+# 2. Mirror the Router image into registry.example.com (see ../README.md)
+
+# 3. Install — chart fetched from the OCI registry once, vendored locally
+helm pull oci://ghcr.io/apollographql/helm-charts/router --version 1.71.0 -d ./vendor
+helm upgrade --install router ./vendor/router-1.71.0.tgz \
+  -f values.yaml \
+  -n apollo
+```
+
+If your CI / control-plane host _also_ can't reach `oci://ghcr.io/...`, swap
+step 3 for a checked-in tarball as in [Pattern A](../pattern-a-local-chart).
+
+## Files
+
+- [`values.yaml`](values.yaml) — annotated values pointing at the private
+  registry with `imagePullSecrets` wired up.
+- [`regcred.example.yaml`](regcred.example.yaml) — declarative form of the
+  secret for GitOps tools (Argo CD, Flux). **Do not commit real credentials.**
+
+## Verifying
+
+```bash
+kubectl -n apollo get pods -l app.kubernetes.io/name=router \
+  -o jsonpath='{.items[0].spec.containers[0].image}'
+# expected: registry.example.com/apollo/router:v2.10.0
+
+kubectl -n apollo describe pod -l app.kubernetes.io/name=router \
+  | grep -E 'Image:|ImagePullSecrets:'
+```

--- a/examples/router-helm-non-oci/pattern-b-private-registry/regcred.example.yaml
+++ b/examples/router-helm-non-oci/pattern-b-private-registry/regcred.example.yaml
@@ -1,0 +1,16 @@
+# Declarative form of the regcred secret, for GitOps tools.
+#
+# DO NOT commit real credentials. The .dockerconfigjson value here is the
+# placeholder from `echo -n '{"auths":{}}' | base64`. Replace it with the
+# real value or — strongly preferred — render it from a sealed/external
+# secret manager (Sealed Secrets, External Secrets Operator, SOPS, Vault).
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: regcred
+  namespace: apollo
+type: kubernetes.io/dockerconfigjson
+data:
+  # base64({"auths":{"registry.example.com":{"username":"...","password":"...","auth":"..."}}})
+  .dockerconfigjson: eyJhdXRocyI6e319

--- a/examples/router-helm-non-oci/pattern-b-private-registry/regcred.example.yaml
+++ b/examples/router-helm-non-oci/pattern-b-private-registry/regcred.example.yaml
@@ -13,4 +13,4 @@ metadata:
 type: kubernetes.io/dockerconfigjson
 data:
   # base64({"auths":{"registry.example.com":{"username":"...","password":"...","auth":"..."}}})
-  .dockerconfigjson: eyJhdXRocyI6e319
+  .dockerconfigjson: eyJhdXRocyI6e319 # gitleaks:allow

--- a/examples/router-helm-non-oci/pattern-b-private-registry/values.yaml
+++ b/examples/router-helm-non-oci/pattern-b-private-registry/values.yaml
@@ -1,0 +1,37 @@
+# Pattern B — non-OCI Router Helm values, private registry with credentials.
+
+router:
+  image:
+    # Replace with your mirrored image location.
+    repository: registry.example.com/apollo/router
+    tag: "v2.10.0"
+    pullPolicy: IfNotPresent
+
+  # Reference the docker-registry secret created with `kubectl create secret
+  # docker-registry regcred`. The chart wires this into the pod spec.
+  imagePullSecrets:
+    - name: regcred
+
+  managedFederation:
+    apolloGraphRef: my-graph@main
+    existingSecret: apollo-graphos-secret # contains APOLLO_KEY
+
+  replicaCount: 3
+  resources:
+    requests:
+      cpu: 500m
+      memory: 512Mi
+    limits:
+      cpu: "2"
+      memory: 2Gi
+
+  service:
+    type: ClusterIP
+    port: 80
+    targetPort: 4000
+
+  podAnnotations:
+    # Adding the registry secret reference to pod annotations is helpful when
+    # tools like external-secrets or sealed-secrets manage the underlying
+    # credential rotation — drop if not applicable to your environment.
+    apollo.example.com/registry: registry.example.com

--- a/examples/router-helm-non-oci/pattern-b-private-registry/values.yaml
+++ b/examples/router-helm-non-oci/pattern-b-private-registry/values.yaml
@@ -1,37 +1,40 @@
 # Pattern B — non-OCI Router Helm values, private registry with credentials.
+#
+# Schema: https://github.com/apollographql/router/blob/main/helm/chart/router/values.yaml
+# All overrides below match the upstream chart's top-level layout. The `router:`
+# key is reserved for the Router YAML config and is intentionally not used here.
 
-router:
-  image:
-    # Replace with your mirrored image location.
-    repository: registry.example.com/apollo/router
-    tag: "v2.10.0"
-    pullPolicy: IfNotPresent
+image:
+  # Replace with your mirrored image location.
+  repository: registry.example.com/apollo/router
+  tag: "v2.10.0"
+  pullPolicy: IfNotPresent
 
-  # Reference the docker-registry secret created with `kubectl create secret
-  # docker-registry regcred`. The chart wires this into the pod spec.
-  imagePullSecrets:
-    - name: regcred
+# Reference the docker-registry secret created with `kubectl create secret
+# docker-registry regcred`. The chart wires this into the pod spec.
+imagePullSecrets:
+  - name: regcred
 
-  managedFederation:
-    apolloGraphRef: my-graph@main
-    existingSecret: apollo-graphos-secret # contains APOLLO_KEY
+managedFederation:
+  graphRef: my-graph@main
+  existingSecret: apollo-graphos-secret # contains the graph API key
 
-  replicaCount: 3
-  resources:
-    requests:
-      cpu: 500m
-      memory: 512Mi
-    limits:
-      cpu: "2"
-      memory: 2Gi
+replicaCount: 3
+resources:
+  requests:
+    cpu: 500m
+    memory: 512Mi
+  limits:
+    cpu: "2"
+    memory: 2Gi
 
-  service:
-    type: ClusterIP
-    port: 80
-    targetPort: 4000
+service:
+  type: ClusterIP
+  port: 80
+  targetport: http
 
-  podAnnotations:
-    # Adding the registry secret reference to pod annotations is helpful when
-    # tools like external-secrets or sealed-secrets manage the underlying
-    # credential rotation — drop if not applicable to your environment.
-    apollo.example.com/registry: registry.example.com
+podAnnotations:
+  # Adding the registry secret reference to pod annotations is helpful when
+  # tools like external-secrets or sealed-secrets manage the underlying
+  # credential rotation — drop if not applicable to your environment.
+  apollo.example.com/registry: registry.example.com


### PR DESCRIPTION
## Summary

Adds two annotated example deployment patterns under `examples/router-helm-non-oci/` for customers whose clusters cannot pull from OCI artifact registries:

- **pattern-a-local-chart** — vendor the chart tarball + use a mirrored image registry. For environments with no outbound OCI access at all.
- **pattern-b-private-registry** — pull the chart once, then deploy with `imagePullSecrets` pointing at a private registry. Includes an External-Secrets-friendly placeholder for the docker-registry secret.

Each pattern README includes a step-by-step install flow, the verification commands to confirm the rendered manifests reference the mirrored image, and inline comments in `values.yaml` calling out exactly which keys differ from the OCI default and why.

Tracks [AS-239](https://apollographql.atlassian.net/browse/AS-239).

## Test plan

- [ ] At least one complete `values.yaml` example exists that configures Apollo Router without OCI image sources
- [ ] The example has been tested (chart renders and Router deploys successfully) — run `helm template router ./vendor/router-1.71.0.tgz -f values.yaml` and verify image points at the mirrored registry
- [ ] Inline comments explain the non-OCI configuration choices
- [ ] The example is stored in a shared location accessible to the SA/SE team (`apollosolutions/reference-architecture`)
- [ ] Any required `imagePullSecrets` configuration is included or documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)